### PR TITLE
Add netstandard 2.0 support

### DIFF
--- a/MimeMapping.csproj
+++ b/MimeMapping.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <Description>Constants for (almost) all MIME types and method to determine MIME type from a file name. Contains just over 1000 mime types.
 
 Generated from the Apache server mime.types file and the H5PB nginx mime.types file. Works similar to .NET's System.Web.MimeMapping.GetMimeMapping.
@@ -14,7 +14,7 @@ https://msdn.microsoft.com/en-us/library/system.web.mimemapping.getmimemapping(v
     <PackageProjectUrl>https://github.com/zone117x/MimeMapping</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/zone117x/MimeMapping/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageTags>mimetype contenttype mime type mimemapping GetMimeMapping media-types rfc 4288</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Matthew Little</Authors>
     <Company />
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Test</RootNamespace>
     <AssemblyName>Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>


### PR DESCRIPTION
This multi targets netstandard 1.1 and 2.0 so anyone who is still on 1.1 can use the latest version. Anyone on .NET 4.7 won't have to pull in all the packages that NetStandard.Library wants though.