### PR TITLE
Update test to use filename generated instead of key name as what loo…

### DIFF
--- a/MimeUtility.cs
+++ b/MimeUtility.cs
@@ -6,31 +6,40 @@ using System.Linq;
 namespace MimeMapping
 {
     /// <summary>
-    ///     MIME type utility to lookup by file extension
+    /// MIME type utility to lookup by file extension
     /// </summary>
     public static class MimeUtility
     {
         /// <summary>
-        ///     The "octet-stream" subtype is used to indicate that a body contains arbitrary binary data.
-        ///     See <a href="https://www.iana.org/assignments/media-types/application/octet-stream">application/octet-stream</a>
+        /// The "octet-stream" subtype is used to indicate that a body contains arbitrary binary data.
+        /// See <a href="https://www.iana.org/assignments/media-types/application/octet-stream">application/octet-stream</a>
         /// </summary>
         public const string UnknownMimeType = "application/octet-stream";
 
-        private static readonly Lazy<ReadOnlyDictionary<string, string>> LazyDict = new Lazy<ReadOnlyDictionary<string, string>>(() => new ReadOnlyDictionary<string, string>(KnownMimeTypes.ALL_EXTS.Value.ToDictionary(e => e, KnownMimeTypes.LookupType)));
+        static Lazy<ReadOnlyDictionary<string, string>> _lazyDict = new Lazy<ReadOnlyDictionary<string, string>>(
+            () => new ReadOnlyDictionary<string, string>(KnownMimeTypes.ALL_EXTS.Value.ToDictionary(e => e, e => KnownMimeTypes.LookupType(e)))
+        );
 
         /// <summary>
-        ///     Dictionary of all available types (lazy loaded on first call)
+        /// Dictionary of all available types (lazy loaded on first call)
         /// </summary>
-        public static ReadOnlyDictionary<string, string> TypeMap => LazyDict.Value;
+        public static ReadOnlyDictionary<string, string> TypeMap => _lazyDict.Value;
 
         /// <param name="file">The file extensions (ex: "zip"), the file name, or file path</param>
         /// <returns>The mime type string, returns "application/octet-stream" if no known type was found</returns>
         public static string GetMimeMapping(string file)
         {
-            if (string.IsNullOrEmpty(file)) return UnknownMimeType;
-            var fileExtension = file.Contains(".") ? Path.GetExtension(file).Substring(1) : file;
-            var mimeType = KnownMimeTypes.LookupType(fileExtension.ToLowerInvariant());
-            return mimeType ?? UnknownMimeType;
+            if (file == null)
+                throw new ArgumentNullException(nameof(file));
+
+            if (string.IsNullOrEmpty(file))
+                return UnknownMimeType;
+
+            var fileExtension = file.Contains(".") 
+                ? Path.GetExtension(file).Substring(1) 
+                : file;
+
+            return KnownMimeTypes.LookupType(fileExtension.ToLowerInvariant()) ?? UnknownMimeType;
         }
     }
 }

--- a/MimeUtility.cs
+++ b/MimeUtility.cs
@@ -6,41 +6,31 @@ using System.Linq;
 namespace MimeMapping
 {
     /// <summary>
-    /// MIME type utility to lookup by file extension
+    ///     MIME type utility to lookup by file extension
     /// </summary>
     public static class MimeUtility
     {
         /// <summary>
-        /// The "octet-stream" subtype is used to indicate that a body contains arbitrary binary data.
-        /// See <a href="https://www.iana.org/assignments/media-types/application/octet-stream">application/octet-stream</a>
+        ///     The "octet-stream" subtype is used to indicate that a body contains arbitrary binary data.
+        ///     See <a href="https://www.iana.org/assignments/media-types/application/octet-stream">application/octet-stream</a>
         /// </summary>
         public const string UnknownMimeType = "application/octet-stream";
 
-        static Lazy<ReadOnlyDictionary<string, string>> _lazyDict = new Lazy<ReadOnlyDictionary<string, string>>(
-            () => new ReadOnlyDictionary<string, string>(KnownMimeTypes.ALL_EXTS.Value.ToDictionary(e => e, e => KnownMimeTypes.LookupType(e)))
-        );
+        private static readonly Lazy<ReadOnlyDictionary<string, string>> LazyDict = new Lazy<ReadOnlyDictionary<string, string>>(() => new ReadOnlyDictionary<string, string>(KnownMimeTypes.ALL_EXTS.Value.ToDictionary(e => e, KnownMimeTypes.LookupType)));
 
         /// <summary>
-        /// Dictionary of all available types (lazy loaded on first call)
+        ///     Dictionary of all available types (lazy loaded on first call)
         /// </summary>
-        public static ReadOnlyDictionary<string, string> TypeMap => _lazyDict.Value;
+        public static ReadOnlyDictionary<string, string> TypeMap => LazyDict.Value;
 
         /// <param name="file">The file extensions (ex: "zip"), the file name, or file path</param>
         /// <returns>The mime type string, returns "application/octet-stream" if no known type was found</returns>
         public static string GetMimeMapping(string file)
         {
-            string fileExtension;
-            if (file.Contains("."))
-            {
-                fileExtension = Path.GetExtension(file).Substring(1);
-            }
-            else
-            {
-                fileExtension = file;
-            }
-            string mimeType = KnownMimeTypes.LookupType(fileExtension.ToLowerInvariant());
+            if (string.IsNullOrEmpty(file)) return UnknownMimeType;
+            var fileExtension = file.Contains(".") ? Path.GetExtension(file).Substring(1) : file;
+            var mimeType = KnownMimeTypes.LookupType(fileExtension.ToLowerInvariant());
             return mimeType ?? UnknownMimeType;
         }
-        
     }
 }

--- a/Test/BasicTest.cs
+++ b/Test/BasicTest.cs
@@ -1,7 +1,6 @@
-using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MimeMapping;
 
 namespace Test
@@ -9,16 +8,17 @@ namespace Test
     [TestClass]
     public class BasicTest
     {
-        Dictionary<string, string> _expectedTypes = new Dictionary<string, string> {
-            { "PNG", "image/png"},
-            { "png", "image/png"},
-            { "JPG", "image/jpeg"},
-            { "mp4", "video/mp4" },
-            { "exe", "application/x-msdownload" },
-            { "zip", "application/zip" },
-            { "torrent", "application/x-bittorrent" },
-            { "json", "application/json" },
-            { "asdfunknown", "application/octet-stream" }
+        private readonly Dictionary<string, string> _expectedTypes = new Dictionary<string, string>
+        {
+            {"PNG", "image/png"},
+            {"png", "image/png"},
+            {"JPG", "image/jpeg"},
+            {"mp4", "video/mp4"},
+            {"exe", "application/x-msdownload"},
+            {"zip", "application/zip"},
+            {"torrent", "application/x-bittorrent"},
+            {"json", "application/json"},
+            {"asdfunknown", "application/octet-stream"}
         };
 
         [TestMethod]
@@ -26,7 +26,8 @@ namespace Test
         {
             foreach (var t in _expectedTypes)
             {
-                var foundType = MimeUtility.GetMimeMapping(t.Key);
+                var filePath = Path.Combine(Path.GetTempPath(), "examplefile." + t.Key);
+                var foundType = MimeUtility.GetMimeMapping(filePath);
                 Assert.AreEqual(t.Value, foundType, "Mime string mismatch");
             }
         }
@@ -36,7 +37,6 @@ namespace Test
         {
             foreach (var t in _expectedTypes)
             {
-                var filePath = Path.Combine(Path.GetTempPath(), "examplefile." + t.Key);
                 var foundType = MimeUtility.GetMimeMapping(t.Key);
                 Assert.AreEqual(t.Value, foundType, "Mime string mismatch");
             }

--- a/Test/BasicTest.cs
+++ b/Test/BasicTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -37,8 +38,39 @@ namespace Test
         {
             foreach (var t in _expectedTypes)
             {
-                var foundType = MimeUtility.GetMimeMapping(t.Key);
+                var filePath = Path.Combine(Path.GetTempPath(), "examplefile." + t.Key);
+                var foundType = MimeUtility.GetMimeMapping(filePath);
                 Assert.AreEqual(t.Value, foundType, "Mime string mismatch");
+            }
+        }
+
+        [TestMethod]
+        public void TestCommonTypesWithOnlyFileNames()
+        {
+            foreach (var t in _expectedTypes)
+            {
+                var fileName = "examplefile." + t.Key;
+                var foundType = MimeUtility.GetMimeMapping(fileName);
+                Assert.AreEqual(t.Value, foundType, "Mime string mismatch");
+            }
+        }
+
+        [TestMethod]
+        public void TestEmptyStringFileArgumentReturnsUnknownMimeType()
+        {
+            Assert.AreEqual(MimeUtility.UnknownMimeType, MimeUtility.GetMimeMapping(string.Empty));
+        }
+
+        [TestMethod]
+        public void TestNullFileArgumentThrowsException()
+        {
+            try
+            {
+                MimeUtility.GetMimeMapping(null);
+            }
+            catch (Exception ex)
+            {
+                Assert.IsInstanceOfType(ex, typeof(ArgumentNullException));
             }
         }
 


### PR DESCRIPTION
- Update test to use filename generated instead of key name as what looked intended.
- Update MimeUtility to handle null file variable. 
   - Assuming return default instead of possible null reference exception or throwing argument null exception is intended by author.