### PR TITLE
ci: fetch full git history for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.5.0
+        with:
+          fetch-depth: 0 # needed so minver finds git tags https://github.com/actions/checkout/issues/172
 
       - uses: actions/cache@v3.3.1
         with:


### PR DESCRIPTION
Current v2 had missing release notes because of this issue. 😕 

I filled the github release manually via github release notes