### PR TITLE
test: Code cleanup in test project

### DIFF
--- a/MimeUtility.cs
+++ b/MimeUtility.cs
@@ -16,11 +16,11 @@ namespace MimeMapping
         /// </summary>
         public const string UnknownMimeType = "application/octet-stream";
 
-        static readonly Lazy<ReadOnlyDictionary<string, string>> _lazyDictExtensions = new Lazy<ReadOnlyDictionary<string, string>>(
+        static Lazy<ReadOnlyDictionary<string, string>> _lazyDictExtensions = new Lazy<ReadOnlyDictionary<string, string>>(
             () => new ReadOnlyDictionary<string, string>(KnownMimeTypes.ALL_EXTS.Value.ToDictionary(e => e, e => KnownMimeTypes.LookupType(e)))
         );
 
-        static readonly Lazy<ReadOnlyDictionary<string, string[]>> _lazyDictMimeTypes = new Lazy<ReadOnlyDictionary<string, string[]>>(
+        static Lazy<ReadOnlyDictionary<string, string[]>> _lazyDictMimeTypes = new Lazy<ReadOnlyDictionary<string, string[]>>(
             () => new ReadOnlyDictionary<string, string[]>(KnownMimeTypes.ALL_MIMETYPES.Value.Distinct().ToDictionary(e => e, e => KnownMimeTypes.LookupMimeType(e)))
         );
 

--- a/MimeUtility.cs
+++ b/MimeUtility.cs
@@ -16,11 +16,11 @@ namespace MimeMapping
         /// </summary>
         public const string UnknownMimeType = "application/octet-stream";
 
-        static Lazy<ReadOnlyDictionary<string, string>> _lazyDictExtensions = new Lazy<ReadOnlyDictionary<string, string>>(
+        static readonly Lazy<ReadOnlyDictionary<string, string>> _lazyDictExtensions = new Lazy<ReadOnlyDictionary<string, string>>(
             () => new ReadOnlyDictionary<string, string>(KnownMimeTypes.ALL_EXTS.Value.ToDictionary(e => e, e => KnownMimeTypes.LookupType(e)))
         );
 
-        static Lazy<ReadOnlyDictionary<string, string[]>> _lazyDictMimeTypes = new Lazy<ReadOnlyDictionary<string, string[]>>(
+        static readonly Lazy<ReadOnlyDictionary<string, string[]>> _lazyDictMimeTypes = new Lazy<ReadOnlyDictionary<string, string[]>>(
             () => new ReadOnlyDictionary<string, string[]>(KnownMimeTypes.ALL_MIMETYPES.Value.Distinct().ToDictionary(e => e, e => KnownMimeTypes.LookupMimeType(e)))
         );
 

--- a/Test/BasicTest.cs
+++ b/Test/BasicTest.cs
@@ -10,7 +10,7 @@ namespace Test
     [TestClass]
     public class BasicTest
     {
-        private readonly Dictionary<string, string> _expectedTypes = new Dictionary<string, string>
+        private readonly Dictionary<string, string> _expectedTypes = new()
         {
             {"PNG", "image/png"},
             {"png", "image/png"},
@@ -94,7 +94,7 @@ namespace Test
         {
             var expected = new[] { KnownMimeTypes.FileExtensions.Json, KnownMimeTypes.FileExtensions.Map };
             var actual = MimeUtility.GetExtensions(KnownMimeTypes.Json);
-            Assert.IsTrue(actual.All(x => expected.Contains(x)));
+            Assert.IsTrue(Array.TrueForAll(actual, x => expected.Contains(x)));
 
             var @null = MimeUtility.GetExtensions("invalid");
             Assert.IsNull(@null);
@@ -122,6 +122,5 @@ namespace Test
                 Assert.IsTrue(kv.Value.Length > 0, $"{kv.Key} cannot have zero extensions.");
             }
         }
-
     }
 }

--- a/Test/Properties/AssemblyInfo.cs
+++ b/Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/Test/TemplateSourceTests.cs
+++ b/Test/TemplateSourceTests.cs
@@ -11,7 +11,7 @@ namespace Test
     [TestClass]
     public class TemplateSourceTests
     {
-        private const string APACHE_URL = "http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types";
+        private const string APACHE_URL = "https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types";
         private const string NGINX_URL = "https://raw.githubusercontent.com/h5bp/server-configs-nginx/master/mime.types";
         private const string MIMEDB_URL = "https://raw.githubusercontent.com/jshttp/mime-db/master/src/custom-types.json";
 
@@ -56,7 +56,7 @@ namespace Test
             Assert.IsTrue(keyPairs.Any());
         }
 
-        private static async ValueTask<string> GetPageContentAsync (string url)
+        private static async ValueTask<string> GetPageContentAsync(string url)
         {
             using var client = new HttpClient();
             return await client.GetStringAsync(url);

--- a/Test/TemplateSourceTests.cs
+++ b/Test/TemplateSourceTests.cs
@@ -51,7 +51,7 @@ namespace Test
                        from mimeTypeProperties in mimeTypes.Children()
                        from mimeTypeProperty in mimeTypeProperties.Children()
                        from mimeTypeValue in mimeTypeProperty.Values()
-                       where (mimeTypeProperty as JProperty)?.Name == "extensions"
+                       where mimeTypeProperty is JProperty { Name: "extensions" }
                        select new[]
                        {
                            mimeType,

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">net6.0</TargetFrameworks>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)/test.runsettings</RunSettingsFilePath>
 	<LangVersion>latest</LangVersion>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -3,14 +3,14 @@
     <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">net6.0</TargetFrameworks>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)/test.runsettings</RunSettingsFilePath>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">net6.0</TargetFrameworks>
+     <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">net8.0;net6.0</TargetFrameworks>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)/test.runsettings</RunSettingsFilePath>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">net6.0</TargetFrameworks>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)/test.runsettings</RunSettingsFilePath>
 	<LangVersion>latest</LangVersion>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I propose the following improvements:
- ~~drop Newtonsoft.Json.Linq in favor of System.Text.Json in tests project~~ will do in separate PR
- add all supported dotnet versions to test project
- minor code cleanup relating code-style
- make tests async