### PR TITLE
ci: add codecov token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         with:
           files: '**/TestResults/*/*.cobertura.xml'
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     needs: [test]


### PR DESCRIPTION
@zone117x please get the token from <https://app.codecov.io/gh/zone117x/MimeMapping/settings> and add it as `CODECOV_TOKEN` secret in GitHub repo settings.

If we don't do it, we won't get code coverage reports. 😢 

- closes #77