### PR TITLE
docs: add constants usage sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,7 @@ foreach(var kp in MimeMapping.MimeTypes.TypeMap)
 {
   Console.WriteLine($"File extension: {kp.Key}, mime string: {kp.Value}");
 }
+
+//Just use a constant if you already know the file type (performance)
+const string mimeType = MimeMapping.KnownMimeTypes.Xlsx
 ```


### PR DESCRIPTION
Hi.

I added a sample in the readme about using a constant when you already know the file type. This is for performance reasons.

I wanted a package like this but without having to call a dictionary or related runtime code. I'm using it in an endpoint that returns an excel file. So it makes sense to use constants as it won't change.

I saw the KnownMimeTypes by luck so I thought it would make sense to have it in the readme.