### PR TITLE
ci: use trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
 
     env:
       CONFIGURATION: Release
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -37,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
           restore-keys: |
             ${{ runner.os }}-nuget
-          
+
       - name: restore
         run: dotnet restore
 
@@ -52,14 +54,20 @@ jobs:
           name: packages
           path: bin/*.nupkg
 
+          # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: deploy nuget.org
         run: find bin -name '*.nupkg' | xargs dotnet nuget push -s $NUGET_SOURCE -k $NUGET_KEY --skip-duplicate --force-english-output
         shell: bash
         env:
           NUGET_SOURCE: https://api.nuget.org/v3/index.json
-          NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
-          
   gh-release:
     needs:
       - nuget-release
@@ -81,7 +89,7 @@ jobs:
         with:
           args: --latest --strip all
           output: 'CHANGELOG.md'
-      
+
       - uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
         with:
           bodyFile: 'CHANGELOG.md'


### PR DESCRIPTION
⚠️  needs configuration first ⚠️ 

- add `NUGET_USER` secret with your `nuget.org` username
- configure policy on `nuget.org`

- https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/